### PR TITLE
Dev getleaderboarddata json

### DIFF
--- a/Orienteering-LR-Desktop/Database/Model.cs
+++ b/Orienteering-LR-Desktop/Database/Model.cs
@@ -12,7 +12,7 @@ namespace Orienteering_LR_Desktop.Database
         public DbSet<Competitor> Competitors { get; set; }
         public DbSet<Club> Clubs { get; set; }
         public DbSet<Team> Teams { get; set; }
-        public DbSet<CompTimes> CompTimes { get; set; }
+        public DbSet<CompTime> CompTimes { get; set; }
         public DbSet<RaceClass> RaceClasses { get; set; }
         public DbSet<Course> Courses { get; set; }
         public DbSet<ClassCourse> ClassCourses { get; set; }
@@ -23,10 +23,10 @@ namespace Orienteering_LR_Desktop.Database
         {
             modelBuilder.Entity<ClassCourse>()
                 .HasKey(c => new { c.RaceClassId, c.Stage, c.CompetitionPos });
-            modelBuilder.Entity<CompTimes>()
+            modelBuilder.Entity<CompTime>()
                 .HasKey(c => new { c.CompetitorId, c.Stage });
             modelBuilder.Entity<Stage>()
-                .HasKey(c => new {c.Name});
+                .HasKey(c => new {c.StageId});
         }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
@@ -43,8 +43,6 @@ namespace Orienteering_LR_Desktop.Database
         public Nullable<int> Age { get; set; }
         public Nullable<int> StartNo { get; set; }
         public string Gender { get; set; }
-        
-        public Nullable<int> ChipId { get; set; }
         
         public Nullable<int> ClubId { get; set; } // fk -> Club
         public Club Club { get; set; }
@@ -65,10 +63,10 @@ namespace Orienteering_LR_Desktop.Database
         public Competitor Competitor { get; set; }
     }
 
-    public class CompTimes {
+    public class CompTime {
         public int CompetitorId { get; set; }
         public Competitor Competitor { get; set; }
-        public string Stage { get; set; }
+        public int Stage { get; set; }
         public int ChipId { get; set; }
         public string Times { get; set; }
     }
@@ -113,7 +111,8 @@ namespace Orienteering_LR_Desktop.Database
 
     public class ClassCourse {
         public int CompetitionPos { get; set; }
-        public string Stage { get; set; }
+        public int Stage { get; set; }
+        public Nullable<int> StartTime { get; set; }
         public int RaceClassId { get; set; }
         public RaceClass RaceClass { get; set; }
         public Nullable<int> CourseId { get; set; }
@@ -123,14 +122,14 @@ namespace Orienteering_LR_Desktop.Database
     public class Punch {
         public int PunchId { get; set; }
         public int ChipId { get; set; }
-        public string Stage { get; set; }
+        public int Stage { get; set; }
         public int CheckpointId { get; set; }
         public int Timestamp { get; set; }
     }
 
     public class Stage
     {
-        public string Name { get; set; } // pk
+        public int StageId { get; set; } // pk
         public bool Current { get; set; }
     }
 

--- a/Orienteering-LR-Desktop/Database/Model.cs
+++ b/Orienteering-LR-Desktop/Database/Model.cs
@@ -7,7 +7,7 @@ using System;
 namespace Orienteering_LR_Desktop.Database
 {
     [NotMapped]
-    class CompetitorContext : DbContext
+    public class CompetitorContext : DbContext
     {
         public DbSet<Competitor> Competitors { get; set; }
         public DbSet<Club> Clubs { get; set; }
@@ -110,7 +110,7 @@ namespace Orienteering_LR_Desktop.Database
     }
 
     public class ClassCourse {
-        public int CompetitionPos { get; set; }
+        public int CompetitionPos { get; set; } // this is just 1 (for now)
         public int Stage { get; set; }
         public Nullable<int> StartTime { get; set; }
         public int RaceClassId { get; set; }

--- a/Orienteering-LR-Desktop/Database/Query.cs
+++ b/Orienteering-LR-Desktop/Database/Query.cs
@@ -133,7 +133,7 @@ namespace Orienteering_LR_Desktop.Database
                             // scan Punches for times instead
                             foreach (int checkpoint in RaceClass.Course.CourseData)
                             {
-                                Database.Punch punch = context.Punches.SingleOrDefault(a => a.ChipId == ChipId && a.Stage == stage && a.CheckpointId == checkpoint);
+                                Punch punch = context.Punches.SingleOrDefault(a => a.ChipId == ChipId && a.Stage == stage && a.CheckpointId == checkpoint);
                                 Times.Add(punch != null ? (Nullable<int>)punch.Timestamp : null);
                             }
 

--- a/Orienteering-LR-Desktop/Database/Query.cs
+++ b/Orienteering-LR-Desktop/Database/Query.cs
@@ -70,7 +70,7 @@ namespace Orienteering_LR_Desktop.Database
                         FirstName = competitor.FirstName,
                         LastName = competitor.LastName
                     };
-                    List<Punch> punches = context.Punches.Where(p => p.ChipId == competitor.ChipId).ToList();
+                    List<Punch> punches = context.Punches.Where(p => p.ChipId == context.CompTimes.Single(a => a.CompetitorId == competitor.CompetitorId && a.Stage == 1).ChipId && p.Stage == 1).ToList();
                     compPunches.Punches = punches;
                     things.Add(compPunches);
                 }
@@ -78,11 +78,11 @@ namespace Orienteering_LR_Desktop.Database
             }
         }
 
-        public string CurrentStage()
+        public int CurrentStage()
         {
             using (var context = new CompetitorContext())
             {
-                return context.Stages.Single(s => s.Current).Name;
+                return context.Stages.Single(s => s.Current).StageId;
             }
         }
     }

--- a/Orienteering-LR-Desktop/Database/Query.cs
+++ b/Orienteering-LR-Desktop/Database/Query.cs
@@ -1,10 +1,434 @@
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace Orienteering_LR_Desktop.Database
 {
+    public class CompetitorInfo : IComparable<CompetitorInfo>
+    {
+        public int CompetitorId;
+        public string FirstName;
+        public string LastName;
+        public Nullable<int> Age;
+        public Nullable<int> StartNo;
+        public string Gender;
+
+        public Club Club;
+        public RaceClassInfo RaceClass;
+
+        public int? ChipId;
+        public int? TeamId;
+
+        public string Status;
+
+        public List<int?> Times;
+
+        public CompetitorInfo()
+        {
+
+        }
+
+        public CompetitorInfo(Competitor competitor, int stage)
+        {
+            Query query = new Query();
+            using (var context = new CompetitorContext())
+            {
+                Initialize(competitor, stage, query, context);
+            }
+        }
+
+        public CompetitorInfo(Competitor competitor, int stage, Query query, CompetitorContext context)
+        {
+            Initialize(competitor, stage, query, context);
+        }
+
+        private void Initialize(Competitor competitor, int stage, Query query, CompetitorContext context)
+        {
+            PartialInitialize(competitor, context);
+
+            if (competitor.RaceClass != null)
+            {
+                RaceClass = new RaceClassInfo(competitor.RaceClass, stage);
+            }
+            else if (competitor.RaceClassId != null)
+            {
+                RaceClass = query.GetRaceClassInfo((int)competitor.RaceClassId, stage);
+            }
+            else
+            {
+                RaceClass = null;
+            }
+
+            GetTimes(stage, context);
+        }
+
+        public void PartialInitialize(Competitor competitor)
+        {
+            using (var context = new CompetitorContext())
+            {
+                PartialInitialize(competitor, context);
+            }
+        }
+
+        //  does not fill RaceClass, ChipId, Status or Times
+        public void PartialInitialize(Competitor competitor, CompetitorContext context)
+        {
+            CompetitorId = competitor.CompetitorId;
+            FirstName = competitor.FirstName;
+            LastName = competitor.LastName;
+            Age = competitor.Age;
+            StartNo = competitor.StartNo;
+            Gender = competitor.Gender;
+            Club = competitor.Club ?? context.Clubs.SingleOrDefault(b => b.ClubId == competitor.ClubId);
+            TeamId = null;  // TODO - with relay support
+        }
+
+        public void GetTimes(int stage)
+        {
+            using (var context = new CompetitorContext())
+            {
+                GetTimes(stage, context);
+            }
+        }
+
+        // fills ChipId, Status, and Times
+        // relies on other fields being filled properly already
+        public void GetTimes(int stage, CompetitorContext context)
+        {
+            Status = "Error";
+            Times = new List<int?>();
+
+            CompTime compTime = context.CompTimes.SingleOrDefault(a => a.CompetitorId == CompetitorId && a.Stage == stage);
+            if (compTime == null)
+            {
+                ChipId = null;
+                Status = "No Chip";
+            }
+            else
+            {
+                ChipId = compTime.ChipId;
+
+                try
+                {
+                    Times = JsonConvert.DeserializeObject<List<int?>>(compTime.Times);
+                    if (Times.Count == 0)
+                    {
+                        // no data sync'd from OE yet (i.e. not yet finished)
+                        if (RaceClass == null)
+                        {
+                            Status = "No Class";
+                        }
+                        else if (RaceClass.Course == null)
+                        {
+                            Status = "No Course";
+                        }
+                        else if (RaceClass.Course.CourseData == null)
+                        {
+                            Status = "Bad Course";
+                        }
+                        else
+                        {
+                            // scan Punches for times instead
+                            foreach (int checkpoint in RaceClass.Course.CourseData)
+                            {
+                                Database.Punch punch = context.Punches.SingleOrDefault(a => a.ChipId == ChipId && a.Stage == stage && a.CheckpointId == checkpoint);
+                                Times.Add(punch != null ? (Nullable<int>)punch.Timestamp : null);
+                            }
+
+                            // if no times
+                            if (Times.Count(s => s != null) == 0)
+                            {
+                                // not yet started
+                                Status = "Ready";
+                            }
+                            else
+                            {
+                                // if there is a finish time
+                                if (Times[Times.Count - 1] != null)
+                                {
+                                    Status = "Provisional";
+                                }
+                                // there are times, but no finish yet
+                                else
+                                {
+                                    Status = "Started";
+                                }
+
+                                // zero the times
+                                int start = 0;
+                                if (Times[0] != null)
+                                {
+                                    start = (int)Times[0];
+                                }
+                                else if (RaceClass.StartTime != null)
+                                {
+                                    start = (int)RaceClass.StartTime;
+                                }
+                                else
+                                {
+                                    Status = "No Start";
+                                    Times.Clear();
+                                }
+
+                                if (start != 0)
+                                {
+                                    // subtract start time from each timestamp
+                                    for (int i = 0; i < Times.Count; i++)
+                                    {
+                                        if (Times[i] != null)
+                                        {
+                                            Times[i] -= start;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        Status = "Finished";
+                    }
+                }
+                catch (Newtonsoft.Json.JsonReaderException)
+                {
+                    // times is a status code
+                    Status = compTime.Times;
+                }
+
+                
+            }
+        }
+
+        public int CompareTo(CompetitorInfo o)
+        {
+            if (o == null)
+            {
+                return -1;
+            }
+            // if this is empty
+            if (Times.Count(s => s != null) == 0)
+            {
+                // if o is also empty
+                if (o.Times.Count(s => s != null) == 0)
+                {
+                    // if this is "Ready"
+                    if (Status == "Ready")
+                    {
+                        // o comes first
+                        return 1;
+                    }
+                    // this is not "Ready"
+                    else
+                    {
+                        // this comes first
+                        return -1;
+                    }
+                }
+                // this is empty but o is not
+                else
+                {
+                    // o comes first
+                    return 1;
+                }
+            }
+            // if this is not empty but o is
+            else if (o.Times.Count(s => s != null) == 0)
+            {
+                // this comes first
+                return -1;
+            }
+            // neither are empty
+            else
+            {
+                // the times at the last scanned checkpoints for this and o
+                int LastTime = (int)Times.Last(a => a != null);
+                int LastTimeo = (int)o.Times.Last(a => a != null);
+                // if they are both at the same checkpoint
+                if (Times.LastIndexOf(LastTime) == o.Times.LastIndexOf(LastTimeo))
+                {
+                    // order by lowest time
+                    return LastTime - LastTimeo;
+                }
+                // otherwise
+                else
+                {
+                    // order by farthest last checkpoint
+                    return o.Times.LastIndexOf(LastTimeo) - Times.LastIndexOf(LastTime);
+                }
+            }
+        }
+    }
+
+    public class RaceClassInfo
+    {
+        public int RaceClassId;
+        public string Abbreviation;
+        public string Name;
+        public Nullable<int> AgeFrom;
+        public Nullable<int> AgeTo;
+        public string Gender;
+        public int RaceClassTypeValue;
+
+        public CourseInfo Course;
+        public int? StartTime;
+
+        // only partially initializes the class (missing Course and StartTime)
+        public RaceClassInfo(RaceClass raceClass)
+        {
+            PartialInitialize(raceClass);
+        }
+
+        public RaceClassInfo(RaceClass raceClass, int stage)
+        {
+            PartialInitialize(raceClass);
+
+            // if there is no matching course for this class/stage then this will be null
+            using (var context = new CompetitorContext())
+            {
+                ClassCourse cc = null;
+                try
+                {
+                    cc = context.ClassCourses.Include(a => a.Course).Single(b => b.RaceClassId == raceClass.RaceClassId && b.Stage == stage && b.CompetitionPos == 1);
+                }
+                catch (InvalidOperationException)
+                {
+                    // if cant retrieve the course leave it as null
+                }
+                StartTime = cc?.StartTime;
+                Course = cc?.Course != null ? new CourseInfo(cc.Course) : null;
+            }
+        }
+
+        // does not fill the Course field or StartTime fields
+        private void PartialInitialize(RaceClass raceClass)
+        {
+            RaceClassId = raceClass.RaceClassId;
+            Abbreviation = raceClass.Abbreviation;
+            Name = raceClass.Name;
+            AgeFrom = raceClass.AgeFrom;
+            AgeTo = raceClass.AgeTo;
+            Gender = raceClass.Gender;
+            RaceClassTypeValue = raceClass._RaceClassTypeValue;
+        }
+    }
+
+    public class CourseInfo
+    {
+        public int CourseId;
+        public Nullable<float> DistanceTotalKm; // in km
+        public Nullable<float> ClimbTotalM; // in m
+        public string Description;
+        public List<int> CourseData;
+        public List<int?> DistanceData;
+
+        public CourseInfo(Course course)
+        {
+            CourseId = course.CourseId;
+            DistanceTotalKm = course.Distance;
+            ClimbTotalM = course.Climb;
+            Description = course.Description;
+
+            try
+            {
+                CourseData = course.CourseData != null ? JsonConvert.DeserializeObject<List<int>>(course.CourseData) : null;
+            }
+            catch (Newtonsoft.Json.JsonReaderException)
+            {
+                CourseData = null;
+            }
+
+            try
+            {
+                DistanceData = course.DistanceData != null ? JsonConvert.DeserializeObject<List<int?>>(course.DistanceData) : null;
+            }
+            catch (Newtonsoft.Json.JsonReaderException)
+            {
+                DistanceData = null;
+            }
+        }
+    }
+
+    // adds a list of the classes that are running this course for a particular stage
+    public class CourseInfoExtended : CourseInfo
+    {
+        public List<RaceClassInfo> Classes;
+
+        public CourseInfoExtended(Course course, int stage) : base(course)
+        {
+            Classes = new List<RaceClassInfo>();
+            using (var context = new CompetitorContext())
+            {
+                foreach (ClassCourse cc in context.ClassCourses.Include(a => a.RaceClass).Where(b => b.CourseId == course.CourseId && b.Stage == stage))
+                {
+                    RaceClassInfo rc = new RaceClassInfo(cc.RaceClass);
+                    rc.StartTime = cc.StartTime;
+                    rc.Course = this;
+                    Classes.Add(rc);
+                }
+            }
+        }
+    }
+
     public class Query
     {
+        public RaceClassInfo GetRaceClassInfo(int raceClassId, int stage)
+        {
+            using (var context = new CompetitorContext())
+            {
+                try
+                {
+                    return new RaceClassInfo(context.RaceClasses.Single(a => a.RaceClassId == raceClassId), stage);
+                }
+                catch (InvalidOperationException)
+                {
+                    // if this raceclassid doesnt exist
+                    return null;
+                }
+            }
+        }
+
+        public Competitor GetCompetitor(int competitorId, int stage)
+        {
+            using (var context = new CompetitorContext())
+            {
+                return context.CompTimes.SingleOrDefault(b => b.CompetitorId == competitorId && b.Stage == stage)?.Competitor;
+            }
+        }
+
+        public CompetitorInfo GetCompetitorInfo(int competitorId, int stage)
+        {
+            using (var context = new CompetitorContext())
+            {
+                try
+                {
+                    return new CompetitorInfo(context.CompTimes.Single(b => b.CompetitorId == competitorId && b.Stage == stage).Competitor, stage, this, context);
+                }
+                catch (InvalidOperationException)
+                {
+                    // if this compid + stage combo doesnt exist
+                    return null;
+                }
+            }
+        }
+
+        public int? FindCompetitorIdByChipId(int chipId, int stage)
+        {
+            using (var context = new CompetitorContext())
+            {
+                return context.CompTimes.SingleOrDefault(b => b.ChipId == chipId && b.Stage == stage)?.CompetitorId;
+            }
+        }
+
+        public int? GetChipId(int competitorId, int stage)
+        {
+            using (var context = new CompetitorContext())
+            {
+                return context.CompTimes.SingleOrDefault(b => b.CompetitorId == competitorId && b.Stage == stage)?.ChipId;
+            }
+        }
+
         public List<RaceClass> GetClasses()
         {
             using (var context = new CompetitorContext())
@@ -14,11 +438,52 @@ namespace Orienteering_LR_Desktop.Database
             }
         }
 
+        public List<RaceClassInfo> GetAllClassInfo(int stage)
+        {
+            using (var context = new CompetitorContext())
+            {
+                List<RaceClassInfo> classes = new List<RaceClassInfo>();
+                foreach (RaceClass raceClass in context.RaceClasses)
+                {
+                    classes.Add(new RaceClassInfo(raceClass, stage));
+                }
+                return classes;
+            }
+        }
+
         public List<Course> GetCourses()
         {
             using (var context = new CompetitorContext())
             {
                 var courses = context.Courses.ToList();
+                return courses;
+            }
+        }
+
+        public List<CourseInfo> GetAllCourseInfo()
+        {
+            using (var context = new CompetitorContext())
+            {
+                List<CourseInfo> courses = new List<CourseInfo>();
+                foreach (Course course in context.Courses)
+                {
+                    courses.Add(new CourseInfo(course));
+                }
+
+                return courses;
+            }
+        }
+
+        public List<CourseInfoExtended> GetAllCourseInfoExtended(int stage)
+        {
+            using (var context = new CompetitorContext())
+            {
+                List<CourseInfoExtended> courses = new List<CourseInfoExtended>();
+                foreach (Course course in context.Courses)
+                {
+                    courses.Add(new CourseInfoExtended(course, stage));
+                }
+
                 return courses;
             }
         }
@@ -37,6 +502,20 @@ namespace Orienteering_LR_Desktop.Database
             using (var context = new CompetitorContext())
             {
                 var competitors = context.Competitors.ToList();
+                return competitors;
+            }
+        }
+
+        public List<CompetitorInfo> GetAllCompetitorInfo(int stage)
+        {
+            using (var context = new CompetitorContext())
+            {
+                List<CompetitorInfo> competitors = new List<CompetitorInfo>();
+                foreach (Competitor comp in context.Competitors)
+                {
+                    competitors.Add(new CompetitorInfo(comp, stage, this, context));
+                }
+
                 return competitors;
             }
         }

--- a/Orienteering-LR-Desktop/Database/Store.cs
+++ b/Orienteering-LR-Desktop/Database/Store.cs
@@ -6,11 +6,11 @@ namespace Orienteering_LR_Desktop.Database
 {
     public class Store
     {
-        public void SetCurrentStage(string stageName)
+        public void SetCurrentStage(int stageId)
         {
             using (var context = new CompetitorContext())
             {
-                var stage = new Stage {Name = stageName, Current = false};
+                var stage = new Stage {StageId = stageId, Current = false};
                 context.Stages.Add(stage);
                 context.SaveChanges();
             }
@@ -20,7 +20,7 @@ namespace Orienteering_LR_Desktop.Database
         {
             using (var context = new CompetitorContext())
             {
-                var punch = new Punch {ChipId = chipId, Stage = "1", CheckpointId = controlId, Timestamp = timestamp};
+                var punch = new Punch {ChipId = chipId, Stage = 1, CheckpointId = controlId, Timestamp = timestamp};
                 context.Punches.Add(punch);
                 context.SaveChanges();
             }
@@ -80,7 +80,7 @@ namespace Orienteering_LR_Desktop.Database
             }
         }
 
-        public void CreateCompTimes(CompTimes compTimes)
+        public void CreateCompTimes(CompTime compTimes)
         {
             using (var context = new CompetitorContext())
             {

--- a/Orienteering-LR-Desktop/GetLeaderboard.cs
+++ b/Orienteering-LR-Desktop/GetLeaderboard.cs
@@ -1,0 +1,246 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Orienteering_LR_Desktop
+{
+    class GetLeaderboard
+    {
+        public class LeaderboardCompetitor : IComparable<LeaderboardCompetitor>
+        {
+            public int CompetitorId;
+            public int ChipNo;
+            public string FirstName;
+            public string LastName;
+            public Nullable<int> Age;
+            public Nullable<int> StartNo;
+            public string Gender;
+            public string Club;
+            public string RaceClass;
+            public string RaceClassFull;
+            public List<Nullable<int>> Times;
+            public string Status;
+
+            public LeaderboardCompetitor(Database.CompTime compTime, Database.RaceClass raceClass)
+            {
+                CompetitorId = compTime.CompetitorId;
+                ChipNo = compTime.ChipId;
+                FirstName = compTime.Competitor.FirstName;
+                LastName = compTime.Competitor.LastName;
+                Age = compTime.Competitor.Age;
+                StartNo = compTime.Competitor.StartNo;
+                Gender = compTime.Competitor.Gender;
+                Club = compTime.Competitor.Club == null ? null : compTime.Competitor.Club.Name;
+                RaceClass = raceClass.Abbreviation;
+                RaceClassFull = raceClass.Name;
+                Times = JsonConvert.DeserializeObject<List<Nullable<int>>>(compTime.Times);
+                Status = "";
+            }
+
+            public int CompareTo(LeaderboardCompetitor o)
+            {
+                if (o == null)
+                {
+                    return -1;
+                }
+                // if this is empty
+                if (Times.Count(s => s != null) == 0)
+                {
+                    // if o is also empty
+                    if (o.Times.Count(s => s != null) == 0)
+                    {
+                        // if this is "Ready"
+                        if (Status == "Ready")
+                        {
+                            // o comes first
+                            return 1;
+                        }
+                        // this is not "Ready"
+                        else
+                        {
+                            // this comes first
+                            return -1;
+                        }
+                    }
+                    // this is empty but o is not
+                    else
+                    {
+                        // o comes first
+                        return 1;
+                    }
+                }
+                // if this is not empty but o is
+                else if (o.Times.Count(s => s != null) == 0)
+                {
+                    // this comes first
+                    return -1;
+                }
+                // neither are empty
+                else
+                {
+                    // the times at the last scanned checkpoints for this and o
+                    int LastTime = (int)Times.Last(a => a != null);
+                    int LastTimeo = (int)o.Times.Last(a => a != null);
+                    // if they are both at the same checkpoint
+                    if (Times.LastIndexOf(LastTime) == o.Times.LastIndexOf(LastTimeo))
+                    {
+                        // order by lowest time
+                        return LastTime - LastTimeo;
+                    }
+                    // otherwise
+                    else
+                    {
+                        // order by farthest last checkpoint
+                        return o.Times.LastIndexOf(LastTimeo) - Times.LastIndexOf(LastTime);
+                    }
+                }
+            }
+        }
+
+        public static string ByClassJson(int raceClassId)
+        {
+            return JsonConvert.SerializeObject(ByClass(raceClassId));
+        }
+
+        public static List<LeaderboardCompetitor> ByClass(int raceClassId)
+        {
+            List<LeaderboardCompetitor> competitors = new List<LeaderboardCompetitor>();
+
+            Database.CompetitorContext context = new Database.CompetitorContext();
+            int currentStage = context.Stages.Single(a => a.Current).StageId;
+            Database.RaceClass raceClass;
+            Database.ClassCourse classCourse;
+            try
+            {
+                raceClass = context.RaceClasses.Single(a => a.RaceClassId == raceClassId);
+                classCourse = context.ClassCourses.Include(a => a.Course).Single(a => a.RaceClassId == raceClassId && a.Stage == currentStage);
+            }
+            catch (InvalidOperationException)
+            {
+                // return empty list if raceClass does not exist or if it does not have an associated course
+                return competitors;
+            }
+
+            List<int> currentCourse = JsonConvert.DeserializeObject<List<int>>(classCourse.Course.CourseData);
+
+
+            foreach (Database.CompTime compTime in context.CompTimes.Include(a => a.Competitor).ThenInclude(a => a.Club).Where(a => a.Stage == currentStage && a.Competitor.RaceClassId == raceClassId))
+            {
+                LeaderboardCompetitor compEntry = new LeaderboardCompetitor(compTime, raceClass);
+
+                // if times is empty (i.e. nothing sync'd from OE) then search for times in punch
+                if (compEntry.Times.Count == 0)
+                {
+                    // get times from Punch
+                    foreach (int checkpoint in currentCourse)
+                    {
+                        // if a checkpoint is missing, time will be null
+                        Database.Punch punch = context.Punches.SingleOrDefault(a => a.ChipId == compTime.ChipId && a.Stage == currentStage && a.CheckpointId == checkpoint);
+                        compEntry.Times.Add(punch == null ? null : (Nullable<int>)punch.Timestamp);
+                    }
+
+                    // if no times
+                    if (compEntry.Times.Count(s => s != null) == 0)
+                    {
+                        // not yet started
+                        compEntry.Status = "Ready";
+                    }
+                    else
+                    {
+                        // if there is a finish time
+                        if (compEntry.Times[compEntry.Times.Count - 1] != null)
+                        {
+                            compEntry.Status = "Provisional";
+                        }
+                        // there are times, but no finish yet
+                        else
+                        {
+                            compEntry.Status = "Started";
+                        }
+
+                        // zero the times to the start
+                        int startTime = 0;
+                        if (compEntry.Times[0] == null)
+                        {
+                            if (classCourse.StartTime != null)
+                            {
+                                startTime = (int)classCourse.StartTime;
+                            }
+                            else
+                            {
+                                // could not find a start time
+                                compEntry.Status = "Error";
+                            }
+                        }
+                        else
+                        {
+                            startTime = (int)compEntry.Times[0];
+                        }
+
+                        // subtract start time from each timestamp
+                        for (int i = 0; i < compEntry.Times.Count; i++)
+                        {
+                            if (compEntry.Times[i] != null)
+                            {
+                                // null all times if no start is found
+                                compEntry.Times[i] = compEntry.Status == "Error" ? null : compEntry.Times[i] - startTime;
+                            }
+                        }
+                    }
+
+
+                }
+                else if (compEntry.Times.Count == 1)
+                {
+                    // TODO check OE status codes
+                    // DNF
+                    // DNS
+                    // DQ
+                }
+                else
+                {
+                    compEntry.Status = "Finished";
+                }
+
+                competitors.Add(compEntry);
+            }
+
+            competitors.Sort();
+
+            return competitors;
+        }
+
+        public static string ByCourseJson(int courseId)
+        {
+            return JsonConvert.SerializeObject(ByCourse(courseId));
+        }
+
+        // gets results for all classes that are running a particular course
+        public static List<LeaderboardCompetitor> ByCourse(int courseId)
+        {
+            using (var context = new Database.CompetitorContext())
+            {
+                List<Nullable<int>> classes = new List<Nullable<int>>();
+                foreach (Database.ClassCourse cc in context.ClassCourses.Where(a => a.CourseId == courseId).ToList())
+                {
+                    classes.Add(cc.RaceClassId);
+                }
+
+                List<LeaderboardCompetitor> leaderboard = new List<LeaderboardCompetitor>();
+
+                foreach (int raceClass in classes)
+                {
+                    leaderboard.AddRange(ByClass(raceClass));
+                }
+
+                leaderboard.Sort();
+
+                return leaderboard;
+            }
+        }
+    }
+}

--- a/Orienteering-LR-Desktop/MainWindow.xaml.cs
+++ b/Orienteering-LR-Desktop/MainWindow.xaml.cs
@@ -51,35 +51,6 @@ namespace Orienteering_LR_Desktop
                 db.GetService<IMigrator>().Migrate();
             }
 
-            var s = new Database.Store();
-            s.CreateClub(new Club()
-            {
-                ClubId = 1
-            });
-
-            s.CreateRaceClass(new RaceClass()
-            {
-                RaceClassId = 1
-            });
-
-            s.CreateCompetitor(new Competitor()
-            {
-                FirstName = "Bob",
-                LastName = "Bobington",
-                ChipId = 2087837,
-                ClubId = 1,
-                RaceClassId = 1
-            });
-
-            s.CreateCompetitor(new Competitor()
-            {
-                FirstName = "Testman",
-                LastName = "Smith",
-                ChipId = 2128274,
-                ClubId = 1,
-                RaceClassId = 1
-            });
-
             // radio punch receiver
             _reader = new Reader
             {
@@ -138,16 +109,13 @@ namespace Orienteering_LR_Desktop
             List<Database.Competitor> Competitors = db.GetCompetitors();
             foreach (Database.Competitor c in Competitors)
             {
-                for (int i = 0; i < 10; i++)
+                CompetitorsList.Add(new Runner()
                 {
-                    CompetitorsList.Add(new Runner()
-                    {
-                        FirstName = c.FirstName,
-                        LastName = c.LastName,
-                        Id = c.ChipId,
-                        Status = "Implement Status Field"
-                    });
-                }
+                    FirstName = c.FirstName,
+                    LastName = c.LastName,
+                    Id = 1,
+                    Status = "Implement Status Field"
+                });
             }
 
             ControlsList.Add(new Control()

--- a/Orienteering-LR-Desktop/MainWindow.xaml.cs
+++ b/Orienteering-LR-Desktop/MainWindow.xaml.cs
@@ -30,7 +30,7 @@ namespace Orienteering_LR_Desktop
     {
         public List<Runner> CompetitorsList = new List<Runner>();
         public List<Control> ControlsList = new List<Control>();
-        public List<Course> CoursesList = new List<Course>();
+        public List<CourseDesktop> CoursesList = new List<CourseDesktop>();
         public List<Runner> Runners = new List<Runner>();
 
         private readonly Reader _reader;
@@ -217,7 +217,7 @@ namespace Orienteering_LR_Desktop
         public Boolean RadioBool { get; set; }
     }
 
-    public class Course
+    public class CourseDesktop
     {
         public List<Control> Controls { get; set; }
         public String Name { get; set; }

--- a/Orienteering-LR-Desktop/Migrations/20190514124920_mig.cs
+++ b/Orienteering-LR-Desktop/Migrations/20190514124920_mig.cs
@@ -43,7 +43,7 @@ namespace Orienteering_LR_Desktop.Migrations
                     PunchId = table.Column<int>(nullable: false)
                         .Annotation("Sqlite:Autoincrement", true),
                     ChipId = table.Column<int>(nullable: false),
-                    Stage = table.Column<string>(nullable: true),
+                    Stage = table.Column<int>(nullable: true),
                     CheckpointId = table.Column<int>(nullable: false),
                     Timestamp = table.Column<int>(nullable: false)
                 },
@@ -75,12 +75,12 @@ namespace Orienteering_LR_Desktop.Migrations
                 name: "Stages",
                 columns: table => new
                 {
-                    Name = table.Column<string>(nullable: false),
+                    StageId = table.Column<int>(nullable: false),
                     Current = table.Column<bool>(nullable: false)
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK_Stages", x => x.Name);
+                    table.PrimaryKey("PK_Stages", x => x.StageId);
                 });
 
             migrationBuilder.CreateTable(
@@ -89,6 +89,7 @@ namespace Orienteering_LR_Desktop.Migrations
                 {
                     RaceClassId = table.Column<int>(nullable: false),
                     CourseId = table.Column<int>(nullable: true),
+                    StartTime = table.Column<int>(nullable: true),
                     CompetitionPos = table.Column<int>(nullable: false),
                     Stage = table.Column<int>(nullable: false)
                 },
@@ -120,7 +121,6 @@ namespace Orienteering_LR_Desktop.Migrations
                     Age = table.Column<int>(nullable: true),
                     StartNo = table.Column<int>(nullable: true),
                     Gender = table.Column<string>(nullable: true),
-                    ChipId = table.Column<int>(nullable: true),
                     ClubId = table.Column<int>(nullable: true),
                     RaceClassId = table.Column<int>(nullable: true)
                 },
@@ -146,7 +146,7 @@ namespace Orienteering_LR_Desktop.Migrations
                 columns: table => new
                 {
                     CompetitorId = table.Column<int>(nullable: false),
-                    Stage = table.Column<string>(nullable: false),
+                    Stage = table.Column<int>(nullable: false),
                     ChipId = table.Column<int>(nullable: false),
                     Times = table.Column<string>(nullable: true)
                 },

--- a/Orienteering-LR-Desktop/Migrations/CompetitorContextModelSnapshot.cs
+++ b/Orienteering-LR-Desktop/Migrations/CompetitorContextModelSnapshot.cs
@@ -23,7 +23,9 @@ namespace Orienteering_LR_Desktop.Migrations
 
                     b.Property<int>("CompetitionPos");
 
-                    b.Property<string>("Stage");
+                    b.Property<int>("StartTime");
+
+                    b.Property<int>("Stage");
 
                     b.HasKey("RaceClassId", "Stage", "CompetitionPos");
 
@@ -50,7 +52,7 @@ namespace Orienteering_LR_Desktop.Migrations
                 {
                     b.Property<int>("CompetitorId");
 
-                    b.Property<string>("Stage");
+                    b.Property<int>("Stage");
 
                     b.Property<int>("ChipId");
 
@@ -67,8 +69,6 @@ namespace Orienteering_LR_Desktop.Migrations
                         .ValueGeneratedOnAdd();
 
                     b.Property<int>("Age");
-
-                    b.Property<int>("ChipId");
 
                     b.Property<int>("ClubId");
 
@@ -120,7 +120,7 @@ namespace Orienteering_LR_Desktop.Migrations
 
                     b.Property<int>("ChipId");
 
-                    b.Property<string>("Stage");
+                    b.Property<int>("Stage");
 
                     b.Property<int>("Timestamp");
 
@@ -155,7 +155,7 @@ namespace Orienteering_LR_Desktop.Migrations
 
             modelBuilder.Entity("Orienteering_LR_Desktop.Database.Stage", b =>
                 {
-                    b.Property<string>("Name")
+                    b.Property<int>("StageId")
                         .ValueGeneratedOnAdd();
 
                     b.Property<bool>("Current");

--- a/Orienteering-LR-Desktop/OESync.cs
+++ b/Orienteering-LR-Desktop/OESync.cs
@@ -275,7 +275,7 @@ namespace Orienteering_LR_Desktop
                         compTime.CompetitorId = comp.CompetitorId;
                         compTime.Competitor = comp;
                         compTime.Stage = 1;
-                        compTime.Times = emptyTimes; // TODO fetch actual times
+                        compTime.Times = emptyTimes; // TODO fetch actual times and status'
                         context.CompTimes.Add(compTime);
                     }
 
@@ -287,7 +287,7 @@ namespace Orienteering_LR_Desktop
                 // tests
                 foreach (Database.RaceClass c in context.RaceClasses.ToList())
                 {
-                    List<GetLeaderboard.LeaderboardCompetitor> leaderboard = GetLeaderboard.ByClass(c.RaceClassId);
+                    //List<GetLeaderboard.LeaderboardCompetitor> leaderboard = GetLeaderboard.ByClass(c.RaceClassId);
                     string leaderboardJson = GetLeaderboard.ByClassJson(c.RaceClassId);
                 }
             }

--- a/Orienteering-LR-Desktop/Orienteering-LR-Desktop.csproj
+++ b/Orienteering-LR-Desktop/Orienteering-LR-Desktop.csproj
@@ -219,6 +219,7 @@
     <Compile Include="Database\Query.cs" />
     <Compile Include="Database\Store.cs" />
     <Compile Include="DbisamRead.cs" />
+    <Compile Include="GetLeaderboard.cs" />
     <Compile Include="MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>


### PR DESCRIPTION
functions to fulfill api calls and desktop app needs.
can just call GetLeaderboard.ByClass(classId) or GetLeaderboard.ByCourse(courseId) or the equivalent -Json() function to get it as a string. Itll pull everything from the database and bundle it up nicely. the subclasses at the top of GetLeaderboard are what gets returned so look at that for what to expect in the web app. It should come pre-sorted.

Also added a bunch of stuff to Query, mostly to fullfil the aforementioned data grabbing/filtering. The new classes/queries can be used for the Desktop app though - specifically if you call Query.GeatAllCompetitorInfo(stage), Query.GetAllCourseInfoExtended(stage), and Query.GetAllClassInfo(stage). can look at the classes to see what youre getting back - it's pretty similar to the model definitions except the lists are de-jsond, some of the linked data is collected more nicely, and specifically all the logic for collecting the competitor times (it'll take the OE times if theyre there, otherwise it'll scan our punches for data) is in CompetitorInfo - it also adds the status field.

some stuff will seem incomplete if you test it - namely no times or status come over from OE but that's missing on the syncing side, this querying should be ok.